### PR TITLE
Update protobuf urls due to migration

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -82,7 +82,7 @@ When the response type is unknown or one wants to debug and see what is all in t
 then this format shows the values for the given field numbers (instead of their field names).
 
 However, since
-[Protobuf is not self-describing](https://developers.google.com/protocol-buffers/docs/techniques#self-description)
+[Protobuf is not self-describing](https://protobuf.dev/programming-guides/techniques/#self-description)
 the types cannot be correctly inferred and may be incorrect.
 
 **JSON**

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See [usage notes](doc/generated.usage.txt), [EXAMPLES.md](EXAMPLES.md) as well a
 
 ## Protobuf JSON Format
 
-protoCURL supports the [Protobuf JSON Format](https://developers.google.com/protocol-buffers/docs/proto3#json). Note,
+protoCURL supports the [Protobuf JSON Format](https://protobuf.dev/programming-guides/proto3/#json). Note,
 that the JSON format is not a straightforward 1:1 mapping as it is in the case of the Protobuf Text Format (described
 below). For instance,
 the [JSON mapping for timestamp.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/timestamp.proto)
@@ -179,10 +179,10 @@ In summary:
 - scalar values are describes similar to JSON. Single and double quotes are both possible for strings.
 - enum values are referenced by their name
 - built-in messages (such
-  as [google.protobuf.Timestamp](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp)
+  as [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp)
   are described just like user-defined custom messages via `{ ... }` and their message fields
 
-The text format is defined in the [Protobuf: Text Format Language Specification](https://developers.google.com/protocol-buffers/docs/text-format-spec).
+The text format is defined in the [Protobuf: Text Format Language Specification](https://protobuf.dev/reference/protobuf/textformat-spec/).
 
 ## Maintainer
 

--- a/doc/template.EXAMPLES.md
+++ b/doc/template.EXAMPLES.md
@@ -46,7 +46,7 @@ When the response type is unknown or one wants to debug and see what is all in t
 then this format shows the values for the given field numbers (instead of their field names).
 
 However, since
-[Protobuf is not self-describing](https://developers.google.com/protocol-buffers/docs/techniques#self-description)
+[Protobuf is not self-describing](https://protobuf.dev/programming-guides/techniques/#self-description)
 the types cannot be correctly inferred and may be incorrect.
 
 **JSON**

--- a/doc/template.README.md
+++ b/doc/template.README.md
@@ -108,7 +108,7 @@ See [usage notes](doc/generated.usage.txt), [EXAMPLES.md](EXAMPLES.md) as well a
 
 ## Protobuf JSON Format
 
-protoCURL supports the [Protobuf JSON Format](https://developers.google.com/protocol-buffers/docs/proto3#json). Note,
+protoCURL supports the [Protobuf JSON Format](https://protobuf.dev/programming-guides/proto3/#json). Note,
 that the JSON format is not a straightforward 1:1 mapping as it is in the case of the Protobuf Text Format (described
 below). For instance,
 the [JSON mapping for timestamp.proto](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/timestamp.proto)
@@ -174,10 +174,10 @@ In summary:
 - scalar values are describes similar to JSON. Single and double quotes are both possible for strings.
 - enum values are referenced by their name
 - built-in messages (such
-  as [google.protobuf.Timestamp](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp)
+  as [google.protobuf.Timestamp](https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp)
   are described just like user-defined custom messages via `{ ... }` and their message fields
 
-The text format is defined in the [Protobuf: Text Format Language Specification](https://developers.google.com/protocol-buffers/docs/text-format-spec).
+The text format is defined in the [Protobuf: Text Format Language Specification](https://protobuf.dev/reference/protobuf/textformat-spec/).
 
 ## Maintainer
 


### PR DESCRIPTION
On the (old) [official google protobuf website](https://developers.google.com/protocol-buffers):
![image](https://user-images.githubusercontent.com/4527862/214248565-dce0c0bb-c465-4e7d-adeb-3e40c158db0c.png)

Hence the URL adaptations