### PR TITLE
enable to overwrite default headers by command line options

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 test/results/*.txt text eol=lf
-**.md text eol=lf
-**.sh text eol=lf
+**/*.md text eol=lf
+**/**.sh text eol=lf

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -146,6 +146,26 @@ will produce no output, exit with a non-zero exitcode and only show this error:
 Error: Request was unsuccessful. Received response status code outside of 2XX. Got: HTTP/1.1 404 Not Found
 ```
 
+**No Default Header**
+
+Some headers use default values (e.g. `Content-Type: application/x-protobuf`). If you do not want to use these default values, use `--no-default-headers` flag (only work when using `--curl`).
+
+```bash
+$ docker run -v "$PWD/test/proto:/proto" --network host qaware/protocurl \
+  -i ..HappyDayRequest -o ..HappyDayResponse \
+  -u http://localhost:8080/happy-day/verify \
+  -d "date: { seconds: 1648044939}" \
+  --curl -n -H 'Content-Type: application/octet-stream'
+
+=========================== Request Text     =========================== >>>
+date: {
+  seconds: 1648044939
+}
+=========================== Response Text    =========================== <<<
+formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
+```
+
+
 **Verbose via -v**
 
 ```bash
@@ -414,7 +434,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Fri, 17 Mar 2023 11:48:00 GMT
+Date: Fri, 17 Mar 2023 23:19:03 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 35
@@ -424,25 +444,6 @@ Content-Length: 35
 00000020  54 22 00                                          |T".|
 Searching for message with base name: HappyDayResponse
 Resolved message package-paths for name HappyDayResponse: [happyday.HappyDayResponse]
-=========================== Response Text    =========================== <<<
-formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
-```
-
-**No Default Header**
-
-Some headers uses default values (e.g. `Content-Type: application/x-protobuf`). If you do not want to use these default values, use `--no-default-headers` flag. You cannot use this flag with go's internal http client.
-
-```bash
-$ docker run -v "$PWD/test/proto:/proto" --network host qaware/protocurl \
-  -i ..HappyDayRequest -o ..HappyDayResponse \
-  -u http://localhost:8080/happy-day/verify \
-  -d "date: { seconds: 1648044939}" \
-  --curl -n -H 'Content-Type: application/octet-stream'
-
-=========================== Request Text     =========================== >>>
-date: {
-  seconds: 1648044939
-}
 =========================== Response Text    =========================== <<<
 formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
 ```

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -170,6 +170,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -413,7 +414,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Sat, 11 Jun 2022 11:15:35 GMT
+Date: Wed, 15 Mar 2023 06:08:50 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 35

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -414,7 +414,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:08:50 GMT
+Date: Fri, 17 Mar 2023 11:48:00 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 35
@@ -424,6 +424,25 @@ Content-Length: 35
 00000020  54 22 00                                          |T".|
 Searching for message with base name: HappyDayResponse
 Resolved message package-paths for name HappyDayResponse: [happyday.HappyDayResponse]
+=========================== Response Text    =========================== <<<
+formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
+```
+
+**No Default Header**
+
+Some headers uses default values (e.g. `Content-Type: application/x-protobuf`). If you do not want to use these default values, use `--no-default-headers` flag. You cannot use this flag with go's internal http client.
+
+```bash
+$ docker run -v "$PWD/test/proto:/proto" --network host qaware/protocurl \
+  -i ..HappyDayRequest -o ..HappyDayResponse \
+  -u http://localhost:8080/happy-day/verify \
+  -d "date: { seconds: 1648044939}" \
+  --curl -n -H 'Content-Type: application/octet-stream'
+
+=========================== Request Text     =========================== >>>
+date: {
+  seconds: 1648044939
+}
 =========================== Response Text    =========================== <<<
 formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
 ```

--- a/doc/generate-docs.sh
+++ b/doc/generate-docs.sh
@@ -171,8 +171,8 @@ $(docker run -v "$WORKING_DIR/test/proto:/proto" --network host protocurl \
 escapeString "$EXAMPLE_4"
 EXAMPLE_4="$ESCAPED"
 
-# EXAMPLE_5 ============================
-EXAMPLE_5="\$ docker run -v \"\$PWD/test/proto:/proto\" --network host qaware/protocurl \\
+# EXAMPLE_NO_DEFAULT_HEADER ============================
+EXAMPLE_NO_DEFAULT_HEADER="\$ docker run -v \"\$PWD/test/proto:/proto\" --network host qaware/protocurl \\
   -i ..HappyDayRequest -o ..HappyDayResponse \\
   -u http://localhost:8080/happy-day/verify \\
   -d \"date: { seconds: 1648044939}\" \\
@@ -184,8 +184,8 @@ $(docker run -v "$WORKING_DIR/test/proto:/proto" --network host protocurl \
   -d "date: { seconds: 1648044939}" \
   --curl -n -H'Content-Type: application/octet-stream')"
 
-escapeString "$EXAMPLE_5"
-EXAMPLE_5="$ESCAPED"
+escapeString "$EXAMPLE_NO_DEFAULT_HEADER"
+EXAMPLE_NO_DEFAULT_HEADER="$ESCAPED"
 
 # replacements ============================
 echo "$EXAMPLES_TEMPLATE" |
@@ -198,8 +198,8 @@ echo "$EXAMPLES_TEMPLATE" |
   sed "s%___EXAMPLE_OUTPUT_ONLY___%$EXAMPLE_OUTPUT_ONLY%" |
   sed "s%___EXAMPLE_OUTPUT_ONLY_WITH_ERR_1___%$EXAMPLE_OUTPUT_ONLY_WITH_ERR_1%" |
   sed "s%___EXAMPLE_OUTPUT_ONLY_WITH_ERR_2___%$EXAMPLE_OUTPUT_ONLY_WITH_ERR_2%" |
-  sed "s%___EXAMPLE_4___%$EXAMPLE_4%" |
-  sed "s%___EXAMPLE_5___%$EXAMPLE_5%" >EXAMPLES.md
+  sed "s%___EXAMPLE_NO_DEFAULT_HEADER___%$EXAMPLE_NO_DEFAULT_HEADER%" |
+  sed "s%___EXAMPLE_4___%$EXAMPLE_4%" >EXAMPLES.md
 
 normaliseOutput EXAMPLES.md
 

--- a/doc/generate-docs.sh
+++ b/doc/generate-docs.sh
@@ -171,6 +171,22 @@ $(docker run -v "$WORKING_DIR/test/proto:/proto" --network host protocurl \
 escapeString "$EXAMPLE_4"
 EXAMPLE_4="$ESCAPED"
 
+# EXAMPLE_5 ============================
+EXAMPLE_5="\$ docker run -v \"\$PWD/test/proto:/proto\" --network host qaware/protocurl \\
+  -i ..HappyDayRequest -o ..HappyDayResponse \\
+  -u http://localhost:8080/happy-day/verify \\
+  -d \"date: { seconds: 1648044939}\" \\
+  --curl -n -H 'Content-Type: application/octet-stream'
+
+$(docker run -v "$WORKING_DIR/test/proto:/proto" --network host protocurl \
+  -i ..HappyDayRequest -o ..HappyDayResponse \
+  -u http://localhost:8080/happy-day/verify \
+  -d "date: { seconds: 1648044939}" \
+  --curl -n -H'Content-Type: application/octet-stream')"
+
+escapeString "$EXAMPLE_5"
+EXAMPLE_5="$ESCAPED"
+
 # replacements ============================
 echo "$EXAMPLES_TEMPLATE" |
   sed "s%___EXAMPLE_1___%$EXAMPLE_1%" |
@@ -182,7 +198,8 @@ echo "$EXAMPLES_TEMPLATE" |
   sed "s%___EXAMPLE_OUTPUT_ONLY___%$EXAMPLE_OUTPUT_ONLY%" |
   sed "s%___EXAMPLE_OUTPUT_ONLY_WITH_ERR_1___%$EXAMPLE_OUTPUT_ONLY_WITH_ERR_1%" |
   sed "s%___EXAMPLE_OUTPUT_ONLY_WITH_ERR_2___%$EXAMPLE_OUTPUT_ONLY_WITH_ERR_2%" |
-  sed "s%___EXAMPLE_4___%$EXAMPLE_4%" >EXAMPLES.md
+  sed "s%___EXAMPLE_4___%$EXAMPLE_4%" |
+  sed "s%___EXAMPLE_5___%$EXAMPLE_5%" >EXAMPLES.md
 
 normaliseOutput EXAMPLES.md
 

--- a/doc/generated.usage.txt
+++ b/doc/generated.usage.txt
@@ -19,25 +19,26 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl

--- a/doc/generated.usage.txt
+++ b/doc/generated.usage.txt
@@ -9,7 +9,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/doc/generated.usage.txt
+++ b/doc/generated.usage.txt
@@ -19,26 +19,26 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl

--- a/doc/template.EXAMPLES.md
+++ b/doc/template.EXAMPLES.md
@@ -82,16 +82,17 @@ will produce no output, exit with a non-zero exitcode and only show this error:
 ___EXAMPLE_OUTPUT_ONLY_WITH_ERR_2___
 ```
 
+**No Default Header**
+
+Some headers use default values (e.g. `Content-Type: application/x-protobuf`). If you do not want to use these default values, use `--no-default-headers` flag (only work when using `--curl`).
+
+```bash
+___EXAMPLE_NO_DEFAULT_HEADER___
+```
+
+
 **Verbose via -v**
 
 ```bash
 ___EXAMPLE_4___
-```
-
-**No Default Header**
-
-Some headers uses default values (e.g. `Content-Type: application/x-protobuf`). If you do not want to use these default values, use `--no-default-headers` flag. You cannot use this flag with go's internal http client.
-
-```bash
-___EXAMPLE_5___
 ```

--- a/doc/template.EXAMPLES.md
+++ b/doc/template.EXAMPLES.md
@@ -87,3 +87,11 @@ ___EXAMPLE_OUTPUT_ONLY_WITH_ERR_2___
 ```bash
 ___EXAMPLE_4___
 ```
+
+**No Default Header**
+
+Some headers uses default values (e.g. `Content-Type: application/x-protobuf`). If you do not want to use these default values, use `--no-default-headers` flag. You cannot use this flag with go's internal http client.
+
+```bash
+___EXAMPLE_5___
+```

--- a/src/flags.go
+++ b/src/flags.go
@@ -85,7 +85,7 @@ func intialiseFlags() {
 	AssertSuccess(rootCmd.MarkFlagRequired("data-text"))
 
 	flags.BoolVarP(&CurrentConfig.NoDefaultHeaders, "no-default-headers", "n", false,
-		"Uses no default headers like `Content-Type`. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.")
+		"Default headers (e.g. \"Content-Type\") will not be passed to curl. Assumes --curl. Use \"-n -H 'Content-Type: FooBar'\" to override the default content type.")
 
 	flags.StringArrayVarP(&CurrentConfig.RequestHeaders, "request-header", "H", []string{},
 		"Adds the `string` header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.")
@@ -212,5 +212,5 @@ func propagateFlags() {
 }
 
 func PanicDueToUnsupportedHeadersWhenInternalHttp(headers []string) {
-	PanicWithMessage(fmt.Sprintf("Custom headers are not supported when  using internal http. Please provide curl in path and avoid using --no-curl. Found headers: %+q", headers))
+	PanicWithMessage(fmt.Sprintf("Non-default or custom headers are not supported when  using internal http. Please provide curl in path and avoid using --no-curl. Found headers: %+q", headers))
 }

--- a/src/flags.go
+++ b/src/flags.go
@@ -84,6 +84,9 @@ func intialiseFlags() {
 			"The format can be set explicitly via --in. See "+GithubRepositoryLink)
 	AssertSuccess(rootCmd.MarkFlagRequired("data-text"))
 
+	flags.BoolVarP(&CurrentConfig.NoDefaultHeaders, "no-default-headers", "n", false,
+		"Uses no default headers like `Content-Type`. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.")
+
 	flags.StringArrayVarP(&CurrentConfig.RequestHeaders, "request-header", "H", []string{},
 		"Adds the `string` header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.")
 

--- a/src/httpRequest.go
+++ b/src/httpRequest.go
@@ -21,7 +21,7 @@ func invokeInternalHttpRequest(requestBinary []byte) ([]byte, string) {
 		fmt.Println("Invoking internal http request.")
 	}
 
-	if !isSupported() {
+	if usingUnsupportedNonDefaultHeaders() {
 		PanicDueToUnsupportedHeadersWhenInternalHttp(CurrentConfig.RequestHeaders)
 	}
 
@@ -40,16 +40,9 @@ func invokeInternalHttpRequest(requestBinary []byte) ([]byte, string) {
 	return body, strings.TrimSpace(headersString)
 }
 
-func isSupported() bool {
-	if CurrentConfig.NoDefaultHeaders {
-		return false
-	}
-
-	if len(CurrentConfig.RequestHeaders) != 1 || CurrentConfig.RequestHeaders[0] != DefaultHeaders[0] {
-		return false
-	}
-
-	return true
+func usingUnsupportedNonDefaultHeaders() bool {
+	usingNonDefaultHeaders := len(CurrentConfig.RequestHeaders) != 1 || CurrentConfig.RequestHeaders[0] != DefaultHeaders[0]
+	return CurrentConfig.NoDefaultHeaders || usingNonDefaultHeaders
 }
 
 func invokeCurlRequest(requestBinary []byte, curlPath string) ([]byte, string) {

--- a/src/httpRequest.go
+++ b/src/httpRequest.go
@@ -21,7 +21,7 @@ func invokeInternalHttpRequest(requestBinary []byte) ([]byte, string) {
 		fmt.Println("Invoking internal http request.")
 	}
 
-	if len(CurrentConfig.RequestHeaders) != 1 || CurrentConfig.RequestHeaders[0] != DefaultHeaders[0] {
+	if !isSupported() {
 		PanicDueToUnsupportedHeadersWhenInternalHttp(CurrentConfig.RequestHeaders)
 	}
 
@@ -38,6 +38,18 @@ func invokeInternalHttpRequest(requestBinary []byte) ([]byte, string) {
 	ensureStatusCodeIs2XX(headersString)
 
 	return body, strings.TrimSpace(headersString)
+}
+
+func isSupported() bool {
+	if CurrentConfig.NoDefaultHeaders {
+		return false
+	}
+
+	if len(CurrentConfig.RequestHeaders) != 1 || CurrentConfig.RequestHeaders[0] != DefaultHeaders[0] {
+		return false
+	}
+
+	return true
 }
 
 func invokeCurlRequest(requestBinary []byte, curlPath string) ([]byte, string) {

--- a/src/protocurl.go
+++ b/src/protocurl.go
@@ -23,6 +23,7 @@ type Config struct {
 	OutTextType          OutTextType
 	DecodeRawResponse    bool
 	DisplayBinaryAndHttp bool
+	NoDefaultHeaders     bool
 	RequestHeaders       []string
 	CustomCurlPath       string
 	AdditionalCurlArgs   string
@@ -172,6 +173,10 @@ func properResponseTypeIfProvidedOrEmptyType() string {
 }
 
 func addDefaultHeaderArgument() {
+	if CurrentConfig.NoDefaultHeaders {
+		return
+	}
+
 	if CurrentConfig.Verbose {
 		fmt.Printf("Adding default header argument to request headers : %s\n", DefaultHeaders)
 	}

--- a/src/protocurl.go
+++ b/src/protocurl.go
@@ -66,7 +66,7 @@ var rootCmd = &cobra.Command{
 		"It uses a bundled '" + ProtocExecutableName + "' (by default) which is used to parse the .proto files.\n" +
 		"The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via '" + ProtocExecutableName + "'.\n" +
 		"If the bundled '" + ProtocExecutableName + "' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.\n" +
-		"The Header 'Content-Type: application/x-protobuf' is set as a request header by default.\n" +
+		"The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)\n" +
 		"When converting between binary and text, the encoding UTF-8 is always used.\n" +
 		"When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.\n\n" +
 		"Enhancements and bugs: " + EnhancementsAndBugsLink,

--- a/test/results/additional-curl-args-expected.txt
+++ b/test/results/additional-curl-args-expected.txt
@@ -10,7 +10,7 @@ includeReason: true
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Tue, 26 Apr 2022 22:34:28 GMT
+Date: Wed, 15 Mar 2023 06:29:40 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/additional-curl-args-expected.txt
+++ b/test/results/additional-curl-args-expected.txt
@@ -10,7 +10,7 @@ includeReason: true
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:40 GMT
+Date: Fri, 17 Mar 2023 11:27:07 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/additional-curl-args-verbose-expected.txt
+++ b/test/results/additional-curl-args-verbose-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -277,7 +278,7 @@ Total curl args:
 * Mark bundle as not supporting multiuse
 < HTTP/1.1 200 OK
 < Content-Type: application/x-protobuf
-< Date: Mon, 16 May 2022 22:09:07 GMT
+< Date: Wed, 15 Mar 2023 06:29:41 GMT
 < Connection: keep-alive
 < Keep-Alive: timeout=5
 < Content-Length: 65
@@ -288,7 +289,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:09:07 GMT
+Date: Wed, 15 Mar 2023 06:29:41 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/additional-curl-args-verbose-expected.txt
+++ b/test/results/additional-curl-args-verbose-expected.txt
@@ -278,7 +278,7 @@ Total curl args:
 * Mark bundle as not supporting multiuse
 < HTTP/1.1 200 OK
 < Content-Type: application/x-protobuf
-< Date: Wed, 15 Mar 2023 06:29:41 GMT
+< Date: Fri, 17 Mar 2023 11:27:08 GMT
 < Connection: keep-alive
 < Keep-Alive: timeout=5
 < Content-Length: 65
@@ -289,7 +289,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:41 GMT
+Date: Fri, 17 Mar 2023 11:27:08 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/display-binary-and-headers-expected.txt
+++ b/test/results/display-binary-and-headers-expected.txt
@@ -10,7 +10,7 @@ includeReason: true
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:38 GMT
+Date: Fri, 17 Mar 2023 11:27:06 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/display-binary-and-headers-expected.txt
+++ b/test/results/display-binary-and-headers-expected.txt
@@ -10,7 +10,7 @@ includeReason: true
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Tue, 26 Apr 2022 22:34:21 GMT
+Date: Wed, 15 Mar 2023 06:29:38 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/display-binary-and-headers-no-curl-expected.txt
+++ b/test/results/display-binary-and-headers-no-curl-expected.txt
@@ -12,7 +12,7 @@ HTTP/1.1 200 OK
 Content-Length: 65
 Connection: keep-alive
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:39 GMT
+Date: Fri, 17 Mar 2023 11:27:07 GMT
 Keep-Alive: timeout=5
 =========================== Response Binary  =========================== <<<
 00000000  08 01 12 1c 54 68 75 72  73 64 61 79 20 69 73 20  |....Thursday is |

--- a/test/results/display-binary-and-headers-no-curl-expected.txt
+++ b/test/results/display-binary-and-headers-no-curl-expected.txt
@@ -12,7 +12,7 @@ HTTP/1.1 200 OK
 Content-Length: 65
 Connection: keep-alive
 Content-Type: application/x-protobuf
-Date: Tue, 26 Apr 2022 22:34:24 GMT
+Date: Wed, 15 Mar 2023 06:29:39 GMT
 Keep-Alive: timeout=5
 =========================== Response Binary  =========================== <<<
 00000000  08 01 12 1c 54 68 75 72  73 64 61 79 20 69 73 20  |....Thursday is |

--- a/test/results/echo-empty-with-curl-args-expected.txt
+++ b/test/results/echo-empty-with-curl-args-expected.txt
@@ -16,7 +16,7 @@ includeReason: true
 * Mark bundle as not supporting multiuse
 < HTTP/1.1 200 OK
 < Content-Type: application/x-protobuf
-< Date: Tue, 26 Apr 2022 22:35:42 GMT
+< Date: Wed, 15 Mar 2023 06:29:56 GMT
 < Connection: keep-alive
 < Keep-Alive: timeout=5
 < Content-Length: 2

--- a/test/results/echo-empty-with-curl-args-expected.txt
+++ b/test/results/echo-empty-with-curl-args-expected.txt
@@ -16,7 +16,7 @@ includeReason: true
 * Mark bundle as not supporting multiuse
 < HTTP/1.1 200 OK
 < Content-Type: application/x-protobuf
-< Date: Wed, 15 Mar 2023 06:29:56 GMT
+< Date: Fri, 17 Mar 2023 11:27:23 GMT
 < Connection: keep-alive
 < Keep-Alive: timeout=5
 < Content-Length: 2

--- a/test/results/far-future-json--v-expected.txt
+++ b/test/results/far-future-json--v-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "json",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -256,7 +257,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:09:10 GMT
+Date: Wed, 15 Mar 2023 06:29:45 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 63

--- a/test/results/far-future-json--v-expected.txt
+++ b/test/results/far-future-json--v-expected.txt
@@ -257,7 +257,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:45 GMT
+Date: Fri, 17 Mar 2023 11:27:12 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 63

--- a/test/results/help-expected.txt
+++ b/test/results/help-expected.txt
@@ -10,7 +10,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/test/results/help-expected.txt
+++ b/test/results/help-expected.txt
@@ -20,28 +20,28 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/help-expected.txt
+++ b/test/results/help-expected.txt
@@ -20,27 +20,28 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/help-missing-curl-expected.txt
+++ b/test/results/help-missing-curl-expected.txt
@@ -10,7 +10,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/test/results/help-missing-curl-expected.txt
+++ b/test/results/help-missing-curl-expected.txt
@@ -20,28 +20,28 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/help-missing-curl-expected.txt
+++ b/test/results/help-missing-curl-expected.txt
@@ -20,27 +20,28 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/help-missing-curl-no-curl-expected.txt
+++ b/test/results/help-missing-curl-no-curl-expected.txt
@@ -10,7 +10,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/test/results/help-missing-curl-no-curl-expected.txt
+++ b/test/results/help-missing-curl-no-curl-expected.txt
@@ -20,28 +20,28 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/help-missing-curl-no-curl-expected.txt
+++ b/test/results/help-missing-curl-no-curl-expected.txt
@@ -20,27 +20,28 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/help-no-curl-expected.txt
+++ b/test/results/help-no-curl-expected.txt
@@ -10,7 +10,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/test/results/help-no-curl-expected.txt
+++ b/test/results/help-no-curl-expected.txt
@@ -20,28 +20,28 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/help-no-curl-expected.txt
+++ b/test/results/help-no-curl-expected.txt
@@ -20,27 +20,28 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/inferred-message-package-path-expected.txt
+++ b/test/results/inferred-message-package-path-expected.txt
@@ -259,7 +259,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:11 GMT
+Date: Fri, 17 Mar 2023 11:26:40 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 68

--- a/test/results/inferred-message-package-path-expected.txt
+++ b/test/results/inferred-message-package-path-expected.txt
@@ -14,6 +14,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -258,7 +259,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:08:45 GMT
+Date: Wed, 15 Mar 2023 06:29:11 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 68

--- a/test/results/inferred-message-package-path-name-clash-explicit-path-expected.txt
+++ b/test/results/inferred-message-package-path-name-clash-explicit-path-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -323,7 +324,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:08:50 GMT
+Date: Wed, 15 Mar 2023 06:29:18 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 68

--- a/test/results/inferred-message-package-path-name-clash-explicit-path-expected.txt
+++ b/test/results/inferred-message-package-path-name-clash-explicit-path-expected.txt
@@ -324,7 +324,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:18 GMT
+Date: Fri, 17 Mar 2023 11:26:47 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 68

--- a/test/results/json-in-text-output-expected.txt
+++ b/test/results/json-in-text-output-expected.txt
@@ -257,7 +257,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:26 GMT
+Date: Fri, 17 Mar 2023 11:26:55 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 68

--- a/test/results/json-in-text-output-expected.txt
+++ b/test/results/json-in-text-output-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -256,7 +257,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:08:57 GMT
+Date: Wed, 15 Mar 2023 06:29:26 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 68

--- a/test/results/missing-args-expected.txt
+++ b/test/results/missing-args-expected.txt
@@ -18,29 +18,29 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl
 
 Error: required flag(s) "data-text","request-type","url" not set
 ######### EXIT 1 #########

--- a/test/results/missing-args-expected.txt
+++ b/test/results/missing-args-expected.txt
@@ -8,7 +8,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/test/results/missing-args-expected.txt
+++ b/test/results/missing-args-expected.txt
@@ -18,28 +18,29 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl
 
 Error: required flag(s) "data-text","request-type","url" not set
 ######### EXIT 1 #########

--- a/test/results/missing-args-no-curl-expected.txt
+++ b/test/results/missing-args-no-curl-expected.txt
@@ -18,29 +18,29 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl
 
 Error: required flag(s) "data-text","request-type","url" not set
 ######### EXIT 1 #########

--- a/test/results/missing-args-no-curl-expected.txt
+++ b/test/results/missing-args-no-curl-expected.txt
@@ -8,7 +8,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/test/results/missing-args-no-curl-expected.txt
+++ b/test/results/missing-args-no-curl-expected.txt
@@ -18,28 +18,29 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl
 
 Error: required flag(s) "data-text","request-type","url" not set
 ######### EXIT 1 #########

--- a/test/results/missing-args-partial-expected.txt
+++ b/test/results/missing-args-partial-expected.txt
@@ -18,29 +18,29 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl
 
 Error: required flag(s) "data-text","url" not set
 ######### EXIT 1 #########

--- a/test/results/missing-args-partial-expected.txt
+++ b/test/results/missing-args-partial-expected.txt
@@ -18,28 +18,29 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl
 
 Error: required flag(s) "data-text","url" not set
 ######### EXIT 1 #########

--- a/test/results/missing-args-partial-expected.txt
+++ b/test/results/missing-args-partial-expected.txt
@@ -8,7 +8,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/test/results/missing-args-partial-no-curl-expected.txt
+++ b/test/results/missing-args-partial-no-curl-expected.txt
@@ -18,29 +18,29 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                              help for protocurl
-      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                           Forces the use of the built-in internal http request instead of curl.
-  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
-      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                        Mandatory: The url to send the request to
-  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
-      --version                           version for protocurl
+      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                      help for protocurl
+      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                   Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers        Default headers (e.g. "Content-Type") will not be passed to curl. Assumes --curl. Use "-n -H 'Content-Type: FooBar'" to override the default content type.
+      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                Mandatory: The url to send the request to
+  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
+      --version                   version for protocurl
 
 Error: required flag(s) "data-text","url" not set
 ######### EXIT 1 #########

--- a/test/results/missing-args-partial-no-curl-expected.txt
+++ b/test/results/missing-args-partial-no-curl-expected.txt
@@ -18,28 +18,29 @@ Examples:
   protocurl -I my-protos -i package.path.Req -o package.path.Resp -u http://example.com/api -d "myField: true, otherField: 1337"
 
 Flags:
-      --curl                      Forces the use of curl executable found in PATH. If none was found, then exits with an error.
-  -C, --curl-args string          Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
-      --curl-path string          Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
-  -d, --data-text string          Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
-      --decode-raw                Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
-  -D, --display-binary-and-http   Displays the binary request and response as well as the non-binary response headers.
-  -h, --help                      help for protocurl
-      --in string                 Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
-  -F, --infer-files               Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
-      --no-curl                   Forces the use of the built-in internal http request instead of curl.
-      --out string                Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
-  -I, --proto-dir string          Uses the specified directory to find the proto-file. (default "/proto")
-  -f, --proto-file string         Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
-      --protoc                    Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
-      --protoc-path string        Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
-  -H, --request-header string     Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
-  -i, --request-type string       Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
-  -o, --response-type string      The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
-  -q, --show-output-only          Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
-  -u, --url string                Mandatory: The url to send the request to
-  -v, --verbose                   Prints version and enables verbose output. Also activates -D.
-      --version                   version for protocurl
+      --curl                              Forces the use of curl executable found in PATH. If none was found, then exits with an error.
+  -C, --curl-args string                  Additional cURL args which will be passed on to cURL during request invocation for further configuration. Also activates --curl.
+      --curl-path string                  Uses the given path to invoke curl instead of searching for curl in PATH. Also activates --curl.
+  -d, --data-text string                  Mandatory: The payload data in Protobuf text format or JSON. It is inferred from the input as JSON if the first token is a '{'. The format can be set explicitly via --in. See https://github.com/qaware/protocurl
+      --decode-raw                        Decode the response into textual format without the schema by only showing field numbers and inferred field types. Types may be incorrect. Only output format text is supported. Use -o <response-type> to see correct contents.
+  -D, --display-binary-and-http           Displays the binary request and response as well as the non-binary response headers.
+  -h, --help                              help for protocurl
+      --in string                         Specifies, in which format the input -d should be interpreted in. 'text' (default) uses the Protobuf text format and 'json' uses JSON. The type is inferred as JSON if the first token is a '{'.
+  -F, --infer-files                       Infer the correct files containing the relevant protobuf messages. All proto files in the proto directory provided by -I will be used. If no -f <file> is provided, this -F is set and the files are inferred.
+      --no-curl                           Forces the use of the built-in internal http request instead of curl.
+  -n, --no-default-headers Content-Type   Uses no default headers like Content-Type. you can use this flag with curl only. E.g. --curl -nH 'Content-Type: FooBar'.
+      --out string                        Produces the output in the specified format. 'text' (default) produces Protobuf text format. 'json' produces dense JSON and 'json:pretty' produces pretty-printed JSON. The produced JSON always uses the original Protobuf field names instead of lowerCamelCasing them.
+  -I, --proto-dir string                  Uses the specified directory to find the proto-file. (default "/proto")
+  -f, --proto-file string                 Uses the specified file path to find the Protobuf definition of the message types within 'proto-dir' (relative file path).
+      --protoc                            Forces the use of a global protoc executable found in PATH or via --protoc-path instead of using the bundled one. If none was found, then exits with an error.
+      --protoc-path string                Uses the given path to invoke protoc instead of searching for protoc in PATH. Also activates --protoc.
+  -H, --request-header string             Adds the string header to the invocation of cURL. This option is not supported when --no-curl is active. E.g. -H 'MyHeader: FooBar'.
+  -i, --request-type string               Mandatory: Message name or full package path of the Protobuf request type. The path can be shortened to '..', if the name of the request message is unique. E.g. mypackage.MyRequest or ..MyRequest
+  -o, --response-type string              The Protobuf response type. See -i <request-type>. Overrides --decode-raw. If not set, then --decode-raw is used.
+  -q, --show-output-only                  Suppresses all output except response Protobuf as text. Overrides and deactivates -v and -D. Errors are still printed to stderr.
+  -u, --url string                        Mandatory: The url to send the request to
+  -v, --verbose                           Prints version and enables verbose output. Also activates -D.
+      --version                           version for protocurl
 
 Error: required flag(s) "data-text","url" not set
 ######### EXIT 1 #########

--- a/test/results/missing-args-partial-no-curl-expected.txt
+++ b/test/results/missing-args-partial-no-curl-expected.txt
@@ -8,7 +8,7 @@ It uses 'curl' from PATH. If none was found, it will fall back to an internal no
 It uses a bundled 'protoc' (by default) which is used to parse the .proto files.
 The bundle also includes the well-known Google Protobuf files necessary to create FileDescriptorSet payloads via 'protoc'.
 If the bundled 'protoc' is used, then these .proto files are included. Otherwise .proto files from the system-wide include are used.
-The Header 'Content-Type: application/x-protobuf' is set as a request header by default.
+The Header 'Content-Type: application/x-protobuf' is set as a request header by default. (disable via -n)
 When converting between binary and text, the encoding UTF-8 is always used.
 When the correct response type is unknown or being debugged, omitting -o <response-type> will attempt to show the response in raw format.
 

--- a/test/results/missing-curl-header-args-not-possible-expected.txt
+++ b/test/results/missing-curl-header-args-not-possible-expected.txt
@@ -6,5 +6,5 @@ date: {
 }
 includeReason: true
 ######### STDERR #########
-Error: Custom headers are not supported when  using internal http. Please provide curl in path and avoid using --no-curl. Found headers: ["Content-Type: application/x-protobuf" "x-abc: def"]
+Error: Non-default or custom headers are not supported when  using internal http. Please provide curl in path and avoid using --no-curl. Found headers: ["Content-Type: application/x-protobuf" "x-abc: def"]
 ######### EXIT 1 #########

--- a/test/results/missing-protoc-expected.txt
+++ b/test/results/missing-protoc-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],

--- a/test/results/missing-protoc-global-expected.txt
+++ b/test/results/missing-protoc-global-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],

--- a/test/results/missing-protocurl-internal-expected.txt
+++ b/test/results/missing-protocurl-internal-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],

--- a/test/results/moved-lib-expected.txt
+++ b/test/results/moved-lib-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],

--- a/test/results/no-default-headers-expected.txt
+++ b/test/results/no-default-headers-expected.txt
@@ -1,0 +1,275 @@
+######### STDOUT #########
+Inferred input text type as text.
+protocurl <version>, build <hash>, https://github.com/qaware/protocurl
+Invoked with following default & parsed arguments:
+{
+  "ProtoFilesDir": "/proto",
+  "ProtoInputFilePath": "happyday.proto",
+  "RequestType": "happyday.HappyDayRequest",
+  "ResponseType": "happyday.HappyDayResponse",
+  "Url": "http://localhost:8080/happy-day/verify",
+  "DataText": "includeReason: true, date: { seconds: 1648044939, nanos: 152000000 }",
+  "InTextType": "text",
+  "OutTextType": "text",
+  "DecodeRawResponse": false,
+  "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": true,
+  "RequestHeaders": [
+    "Content-Type: application/octet-stream"
+  ],
+  "CustomCurlPath": "",
+  "AdditionalCurlArgs": "",
+  "Verbose": true,
+  "ShowOutputOnly": false,
+  "ForceNoCurl": false,
+  "ForceCurl": true,
+  "GlobalProtoc": false,
+  "CustomProtocPath": "",
+  "InferProtoFiles": false
+}
+Found bundled protoc at /protocurl/protocurl-internal/bin/protoc
+Using google protobuf include: /protocurl/protocurl-internal/include
+Converting file happyday.proto in /proto to a FileDescriptorSet.
+=========================== .proto descriptor ===========================
+file: {
+  name: "google/protobuf/timestamp.proto"
+  package: "google.protobuf"
+  message_type: {
+    name: "Timestamp"
+    field: {
+      name: "seconds"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "seconds"
+    }
+    field: {
+      name: "nanos"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "nanos"
+    }
+  }
+  options: {
+    java_package: "com.google.protobuf"
+    java_outer_classname: "TimestampProto"
+    java_multiple_files: true
+    go_package: "google.golang.org/protobuf/types/known/timestamppb"
+    cc_enable_arenas: true
+    objc_class_prefix: "GPB"
+    csharp_namespace: "Google.Protobuf.WellKnownTypes"
+  }
+  syntax: "proto3"
+}
+file: {
+  name: "happyday.proto"
+  package: "happyday"
+  dependency: "google/protobuf/timestamp.proto"
+  message_type: {
+    name: "HappyDayRequest"
+    field: {
+      name: "date"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".google.protobuf.Timestamp"
+      json_name: "date"
+    }
+    field: {
+      name: "includeReason"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "includeReason"
+    }
+    field: {
+      name: "double"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_DOUBLE
+      json_name: "double"
+    }
+    field: {
+      name: "int32"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_INT32
+      json_name: "int32"
+    }
+    field: {
+      name: "int64"
+      number: 5
+      label: LABEL_OPTIONAL
+      type: TYPE_INT64
+      json_name: "int64"
+    }
+    field: {
+      name: "string"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "string"
+    }
+    field: {
+      name: "bytes"
+      number: 7
+      label: LABEL_OPTIONAL
+      type: TYPE_BYTES
+      json_name: "bytes"
+    }
+    field: {
+      name: "fooEnum"
+      number: 8
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".happyday.Foo"
+      json_name: "fooEnum"
+    }
+    field: {
+      name: "misc"
+      number: 9
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".happyday.MiscInfo"
+      json_name: "misc"
+    }
+    field: {
+      name: "float"
+      number: 10
+      label: LABEL_OPTIONAL
+      type: TYPE_FLOAT
+      json_name: "float"
+    }
+    field: {
+      name: "NonCamel_case_FieldName"
+      number: 11
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "NonCamelCaseFieldName"
+    }
+  }
+  message_type: {
+    name: "HappyDayResponse"
+    field: {
+      name: "isHappyDay"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_BOOL
+      json_name: "isHappyDay"
+    }
+    field: {
+      name: "reason"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "reason"
+    }
+    field: {
+      name: "formattedDate"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "formattedDate"
+    }
+    field: {
+      name: "err"
+      number: 4
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "err"
+    }
+  }
+  message_type: {
+    name: "MiscInfo"
+    field: {
+      name: "weatherOfPastFewDays"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_STRING
+      json_name: "weatherOfPastFewDays"
+    }
+    field: {
+      name: "fooString"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      oneof_index: 0
+      json_name: "fooString"
+    }
+    field: {
+      name: "fooEnum"
+      number: 3
+      label: LABEL_OPTIONAL
+      type: TYPE_ENUM
+      type_name: ".happyday.Foo"
+      oneof_index: 0
+      json_name: "fooEnum"
+    }
+    oneof_decl: {
+      name: "alternative"
+    }
+  }
+  enum_type: {
+    name: "Foo"
+    value: {
+      name: "BAR"
+      number: 0
+    }
+    value: {
+      name: "BAZ"
+      number: 1
+    }
+    value: {
+      name: "FAZ"
+      number: 2
+    }
+  }
+  syntax: "proto3"
+}
+Looking up message with full name: happyday.HappyDayRequest
+Looking up message with full name: happyday.HappyDayRequest
+=========================== Request Text     =========================== >>>
+date: {
+  seconds: 1648044939
+  nanos: 152000000
+}
+includeReason: true
+=========================== Request Binary   =========================== >>>
+00000000  0a 0b 08 8b d7 ec 91 06  10 80 ac bd 48 10 01     |............H..|
+Expecting to find curl executable due to forced use of curl.
+Found curl: /usr/bin/curl
+Invoking curl http request.
+Understood additional curl args: []
+Total curl args:
+  -s
+  -X
+  POST
+  --data-binary
+  @<tmp>
+  --output
+  <tmp>
+  --dump-header
+  <tmp>
+  -H
+  Content-Type: application/octet-stream
+  http://localhost:8080/happy-day/verify
+=========================== Response Headers =========================== <<<
+HTTP/1.1 200 OK
+Content-Type: application/x-protobuf
+Date: Wed, 15 Mar 2023 06:30:09 GMT
+Connection: keep-alive
+Keep-Alive: timeout=5
+Content-Length: 68
+=========================== Response Binary  =========================== <<<
+00000000  08 00 12 1f 54 6f 75 67  68 20 6c 75 63 6b 20 6f  |....Tough luck o|
+00000010  6e 20 57 65 64 6e 65 73  64 61 79 2e 2e 2e 20 f0  |n Wednesday... .|
+00000020  9f 98 95 1a 1d 57 65 64  2c 20 32 33 20 4d 61 72  |.....Wed, 23 Mar|
+00000030  20 32 30 32 32 20 31 34  3a 31 35 3a 33 39 20 47  | 2022 14:15:39 G|
+00000040  4d 54 22 00                                       |MT".|
+Looking up message with full name: happyday.HappyDayResponse
+=========================== Response Text    =========================== <<<
+reason: "Tough luck on Wednesday... 😕"
+formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
+######### STDERR #########
+######### EXIT 0 #########

--- a/test/results/no-default-headers-with-custom-content-type-header-expected.txt
+++ b/test/results/no-default-headers-with-custom-content-type-header-expected.txt
@@ -1,7 +1,6 @@
 ######### STDOUT #########
 Inferred input text type as text.
 protocurl <version>, build <hash>, https://github.com/qaware/protocurl
-Adding default header argument to request headers : [Content-Type: application/x-protobuf]
 Invoked with following default & parsed arguments:
 {
   "ProtoFilesDir": "/proto",
@@ -9,21 +8,21 @@ Invoked with following default & parsed arguments:
   "RequestType": "happyday.HappyDayRequest",
   "ResponseType": "happyday.HappyDayResponse",
   "Url": "http://localhost:8080/happy-day/verify",
-  "DataText": "includeReason: true, date: { seconds: 1642044939, nanos: 152000000 }",
+  "DataText": "includeReason: true, date: { seconds: 1648044939, nanos: 152000000 }",
   "InTextType": "text",
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
-  "NoDefaultHeaders": false,
+  "NoDefaultHeaders": true,
   "RequestHeaders": [
-    "Content-Type: application/x-protobuf"
+    "Content-Type: application/octet-stream"
   ],
   "CustomCurlPath": "",
   "AdditionalCurlArgs": "",
   "Verbose": true,
   "ShowOutputOnly": false,
   "ForceNoCurl": false,
-  "ForceCurl": false,
+  "ForceCurl": true,
   "GlobalProtoc": false,
   "CustomProtocPath": "",
   "InferProtoFiles": false
@@ -232,12 +231,13 @@ Looking up message with full name: happyday.HappyDayRequest
 Looking up message with full name: happyday.HappyDayRequest
 =========================== Request Text     =========================== >>>
 date: {
-  seconds: 1642044939
+  seconds: 1648044939
   nanos: 152000000
 }
 includeReason: true
 =========================== Request Binary   =========================== >>>
-00000000  0a 0b 08 8b bc fe 8e 06  10 80 ac bd 48 10 01     |............H..|
+00000000  0a 0b 08 8b d7 ec 91 06  10 80 ac bd 48 10 01     |............H..|
+Expecting to find curl executable due to forced use of curl.
 Found curl: /usr/bin/curl
 Invoking curl http request.
 Understood additional curl args: []
@@ -252,25 +252,24 @@ Total curl args:
   --dump-header
   <tmp>
   -H
-  Content-Type: application/x-protobuf
+  Content-Type: application/octet-stream
   http://localhost:8080/happy-day/verify
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Fri, 17 Mar 2023 11:27:02 GMT
+Date: Fri, 17 Mar 2023 11:27:37 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
-Content-Length: 65
+Content-Length: 68
 =========================== Response Binary  =========================== <<<
-00000000  08 01 12 1c 54 68 75 72  73 64 61 79 20 69 73 20  |....Thursday is |
-00000010  61 20 48 61 70 70 79 20  44 61 79 21 20 e2 ad 90  |a Happy Day! ...|
-00000020  1a 1d 54 68 75 2c 20 31  33 20 4a 61 6e 20 32 30  |..Thu, 13 Jan 20|
-00000030  32 32 20 30 33 3a 33 35  3a 33 39 20 47 4d 54 22  |22 03:35:39 GMT"|
-00000040  00                                                |.|
+00000000  08 00 12 1f 54 6f 75 67  68 20 6c 75 63 6b 20 6f  |....Tough luck o|
+00000010  6e 20 57 65 64 6e 65 73  64 61 79 2e 2e 2e 20 f0  |n Wednesday... .|
+00000020  9f 98 95 1a 1d 57 65 64  2c 20 32 33 20 4d 61 72  |.....Wed, 23 Mar|
+00000030  20 32 30 32 32 20 31 34  3a 31 35 3a 33 39 20 47  | 2022 14:15:39 G|
+00000040  4d 54 22 00                                       |MT".|
 Looking up message with full name: happyday.HappyDayResponse
 =========================== Response Text    =========================== <<<
-isHappyDay: true
-reason: "Thursday is a Happy Day! ⭐"
-formattedDate: "Thu, 13 Jan 2022 03:35:39 GMT"
+reason: "Tough luck on Wednesday... 😕"
+formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/no-default-headers-with-no-additional-headers-expected.txt
+++ b/test/results/no-default-headers-with-no-additional-headers-expected.txt
@@ -1,7 +1,6 @@
 ######### STDOUT #########
 Inferred input text type as text.
 protocurl <version>, build <hash>, https://github.com/qaware/protocurl
-Adding default header argument to request headers : [Content-Type: application/x-protobuf]
 Invoked with following default & parsed arguments:
 {
   "ProtoFilesDir": "/proto",
@@ -9,21 +8,19 @@ Invoked with following default & parsed arguments:
   "RequestType": "happyday.HappyDayRequest",
   "ResponseType": "happyday.HappyDayResponse",
   "Url": "http://localhost:8080/happy-day/verify",
-  "DataText": "includeReason: true, date: { seconds: 1642044939, nanos: 152000000 }",
+  "DataText": "includeReason: true, date: { seconds: 1648044939, nanos: 152000000 }",
   "InTextType": "text",
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
-  "NoDefaultHeaders": false,
-  "RequestHeaders": [
-    "Content-Type: application/x-protobuf"
-  ],
+  "NoDefaultHeaders": true,
+  "RequestHeaders": [],
   "CustomCurlPath": "",
   "AdditionalCurlArgs": "",
   "Verbose": true,
   "ShowOutputOnly": false,
   "ForceNoCurl": false,
-  "ForceCurl": false,
+  "ForceCurl": true,
   "GlobalProtoc": false,
   "CustomProtocPath": "",
   "InferProtoFiles": false
@@ -232,12 +229,13 @@ Looking up message with full name: happyday.HappyDayRequest
 Looking up message with full name: happyday.HappyDayRequest
 =========================== Request Text     =========================== >>>
 date: {
-  seconds: 1642044939
+  seconds: 1648044939
   nanos: 152000000
 }
 includeReason: true
 =========================== Request Binary   =========================== >>>
-00000000  0a 0b 08 8b bc fe 8e 06  10 80 ac bd 48 10 01     |............H..|
+00000000  0a 0b 08 8b d7 ec 91 06  10 80 ac bd 48 10 01     |............H..|
+Expecting to find curl executable due to forced use of curl.
 Found curl: /usr/bin/curl
 Invoking curl http request.
 Understood additional curl args: []
@@ -251,26 +249,23 @@ Total curl args:
   <tmp>
   --dump-header
   <tmp>
-  -H
-  Content-Type: application/x-protobuf
   http://localhost:8080/happy-day/verify
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Fri, 17 Mar 2023 11:27:02 GMT
+Date: Fri, 17 Mar 2023 11:27:36 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
-Content-Length: 65
+Content-Length: 68
 =========================== Response Binary  =========================== <<<
-00000000  08 01 12 1c 54 68 75 72  73 64 61 79 20 69 73 20  |....Thursday is |
-00000010  61 20 48 61 70 70 79 20  44 61 79 21 20 e2 ad 90  |a Happy Day! ...|
-00000020  1a 1d 54 68 75 2c 20 31  33 20 4a 61 6e 20 32 30  |..Thu, 13 Jan 20|
-00000030  32 32 20 30 33 3a 33 35  3a 33 39 20 47 4d 54 22  |22 03:35:39 GMT"|
-00000040  00                                                |.|
+00000000  08 00 12 1f 54 6f 75 67  68 20 6c 75 63 6b 20 6f  |....Tough luck o|
+00000010  6e 20 57 65 64 6e 65 73  64 61 79 2e 2e 2e 20 f0  |n Wednesday... .|
+00000020  9f 98 95 1a 1d 57 65 64  2c 20 32 33 20 4d 61 72  |.....Wed, 23 Mar|
+00000030  20 32 30 32 32 20 31 34  3a 31 35 3a 33 39 20 47  | 2022 14:15:39 G|
+00000040  4d 54 22 00                                       |MT".|
 Looking up message with full name: happyday.HappyDayResponse
 =========================== Response Text    =========================== <<<
-isHappyDay: true
-reason: "Thursday is a Happy Day! ⭐"
-formattedDate: "Thu, 13 Jan 2022 03:35:39 GMT"
+reason: "Tough luck on Wednesday... 😕"
+formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
 ######### STDERR #########
 ######### EXIT 0 #########

--- a/test/results/no-default-headers-with-no-curl-flag-expected.txt
+++ b/test/results/no-default-headers-with-no-curl-flag-expected.txt
@@ -14,15 +14,13 @@ Invoked with following default & parsed arguments:
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
   "NoDefaultHeaders": true,
-  "RequestHeaders": [
-    "Content-Type: application/octet-stream"
-  ],
+  "RequestHeaders": [],
   "CustomCurlPath": "",
   "AdditionalCurlArgs": "",
   "Verbose": true,
   "ShowOutputOnly": false,
-  "ForceNoCurl": false,
-  "ForceCurl": true,
+  "ForceNoCurl": true,
+  "ForceCurl": false,
   "GlobalProtoc": false,
   "CustomProtocPath": "",
   "InferProtoFiles": false
@@ -237,39 +235,8 @@ date: {
 includeReason: true
 =========================== Request Binary   =========================== >>>
 00000000  0a 0b 08 8b d7 ec 91 06  10 80 ac bd 48 10 01     |............H..|
-Expecting to find curl executable due to forced use of curl.
-Found curl: /usr/bin/curl
-Invoking curl http request.
-Understood additional curl args: []
-Total curl args:
-  -s
-  -X
-  POST
-  --data-binary
-  @<tmp>
-  --output
-  <tmp>
-  --dump-header
-  <tmp>
-  -H
-  Content-Type: application/octet-stream
-  http://localhost:8080/happy-day/verify
-=========================== Response Headers =========================== <<<
-HTTP/1.1 200 OK
-Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:30:09 GMT
-Connection: keep-alive
-Keep-Alive: timeout=5
-Content-Length: 68
-=========================== Response Binary  =========================== <<<
-00000000  08 00 12 1f 54 6f 75 67  68 20 6c 75 63 6b 20 6f  |....Tough luck o|
-00000010  6e 20 57 65 64 6e 65 73  64 61 79 2e 2e 2e 20 f0  |n Wednesday... .|
-00000020  9f 98 95 1a 1d 57 65 64  2c 20 32 33 20 4d 61 72  |.....Wed, 23 Mar|
-00000030  20 32 30 32 32 20 31 34  3a 31 35 3a 33 39 20 47  | 2022 14:15:39 G|
-00000040  4d 54 22 00                                       |MT".|
-Looking up message with full name: happyday.HappyDayResponse
-=========================== Response Text    =========================== <<<
-reason: "Tough luck on Wednesday... 😕"
-formattedDate: "Wed, 23 Mar 2022 14:15:39 GMT"
+Using internal http request due to forced avoidance of curl.
+Invoking internal http request.
 ######### STDERR #########
-######### EXIT 0 #########
+Error: Non-default or custom headers are not supported when  using internal http. Please provide curl in path and avoid using --no-curl. Found headers: []
+######### EXIT 1 #########

--- a/test/results/response-type-arg-inferred-decode-raw-expected.txt
+++ b/test/results/response-type-arg-inferred-decode-raw-expected.txt
@@ -259,7 +259,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:16 GMT
+Date: Fri, 17 Mar 2023 11:26:45 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/response-type-arg-inferred-decode-raw-expected.txt
+++ b/test/results/response-type-arg-inferred-decode-raw-expected.txt
@@ -16,6 +16,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": true,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -258,7 +259,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Tue, 17 May 2022 21:49:45 GMT
+Date: Wed, 15 Mar 2023 06:29:16 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/response-type-arg-overidden-decode-raw-expected.txt
+++ b/test/results/response-type-arg-overidden-decode-raw-expected.txt
@@ -16,6 +16,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -257,7 +258,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Tue, 17 May 2022 21:49:46 GMT
+Date: Wed, 15 Mar 2023 06:29:17 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/response-type-arg-overidden-decode-raw-expected.txt
+++ b/test/results/response-type-arg-overidden-decode-raw-expected.txt
@@ -258,7 +258,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:17 GMT
+Date: Fri, 17 Mar 2023 11:26:46 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/text-in-json-output-expected.txt
+++ b/test/results/text-in-json-output-expected.txt
@@ -261,7 +261,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:26 GMT
+Date: Fri, 17 Mar 2023 11:26:54 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 68

--- a/test/results/text-in-json-output-expected.txt
+++ b/test/results/text-in-json-output-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "json",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -260,7 +261,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:08:56 GMT
+Date: Wed, 15 Mar 2023 06:29:26 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 68

--- a/test/results/verbose-custom-headers-expected.txt
+++ b/test/results/verbose-custom-headers-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf",
     "x-abc: def",
@@ -266,7 +267,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:09:03 GMT
+Date: Wed, 15 Mar 2023 06:29:35 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/verbose-custom-headers-expected.txt
+++ b/test/results/verbose-custom-headers-expected.txt
@@ -267,7 +267,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:35 GMT
+Date: Fri, 17 Mar 2023 11:27:02 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/verbose-custom-headers-no-curl-expected.txt
+++ b/test/results/verbose-custom-headers-no-curl-expected.txt
@@ -2,5 +2,5 @@
 Inferred input text type as text.
 Infering proto files (-F), since -f <file> was not provided.
 ######### STDERR #########
-Error: Custom headers are not supported when  using internal http. Please provide curl in path and avoid using --no-curl. Found headers: ["x-abc: def" "x-ghi: jkl"]
+Error: Non-default or custom headers are not supported when  using internal http. Please provide curl in path and avoid using --no-curl. Found headers: ["x-abc: def" "x-ghi: jkl"]
 ######### EXIT 1 #########

--- a/test/results/verbose-expected.txt
+++ b/test/results/verbose-expected.txt
@@ -14,6 +14,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -256,7 +257,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:09:01 GMT
+Date: Wed, 15 Mar 2023 06:29:32 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/verbose-expected.txt
+++ b/test/results/verbose-expected.txt
@@ -257,7 +257,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:32 GMT
+Date: Fri, 17 Mar 2023 11:27:00 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/verbose-long-args-equals-args-expected.txt
+++ b/test/results/verbose-long-args-equals-args-expected.txt
@@ -14,6 +14,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -256,7 +257,7 @@ Total curl args:
 =========================== Response Headers =========================== <<<
 HTTP/1.1 200 OK
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:09:02 GMT
+Date: Wed, 15 Mar 2023 06:29:34 GMT
 Connection: keep-alive
 Keep-Alive: timeout=5
 Content-Length: 65

--- a/test/results/verbose-missing-curl-expected.txt
+++ b/test/results/verbose-missing-curl-expected.txt
@@ -249,7 +249,7 @@ HTTP/1.1 200 OK
 Content-Length: 65
 Connection: keep-alive
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:36 GMT
+Date: Fri, 17 Mar 2023 11:27:04 GMT
 Keep-Alive: timeout=5
 =========================== Response Binary  =========================== <<<
 00000000  08 01 12 1c 54 68 75 72  73 64 61 79 20 69 73 20  |....Thursday is |

--- a/test/results/verbose-missing-curl-expected.txt
+++ b/test/results/verbose-missing-curl-expected.txt
@@ -15,6 +15,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -248,7 +249,7 @@ HTTP/1.1 200 OK
 Content-Length: 65
 Connection: keep-alive
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:09:04 GMT
+Date: Wed, 15 Mar 2023 06:29:36 GMT
 Keep-Alive: timeout=5
 =========================== Response Binary  =========================== <<<
 00000000  08 01 12 1c 54 68 75 72  73 64 61 79 20 69 73 20  |....Thursday is |

--- a/test/results/verbose-no-curl-expected.txt
+++ b/test/results/verbose-no-curl-expected.txt
@@ -245,7 +245,7 @@ HTTP/1.1 200 OK
 Content-Length: 65
 Connection: keep-alive
 Content-Type: application/x-protobuf
-Date: Wed, 15 Mar 2023 06:29:33 GMT
+Date: Fri, 17 Mar 2023 11:27:01 GMT
 Keep-Alive: timeout=5
 =========================== Response Binary  =========================== <<<
 00000000  08 01 12 1c 54 68 75 72  73 64 61 79 20 69 73 20  |....Thursday is |

--- a/test/results/verbose-no-curl-expected.txt
+++ b/test/results/verbose-no-curl-expected.txt
@@ -14,6 +14,7 @@ Invoked with following default & parsed arguments:
   "OutTextType": "text",
   "DecodeRawResponse": false,
   "DisplayBinaryAndHttp": true,
+  "NoDefaultHeaders": false,
   "RequestHeaders": [
     "Content-Type: application/x-protobuf"
   ],
@@ -244,7 +245,7 @@ HTTP/1.1 200 OK
 Content-Length: 65
 Connection: keep-alive
 Content-Type: application/x-protobuf
-Date: Mon, 16 May 2022 22:09:02 GMT
+Date: Wed, 15 Mar 2023 06:29:33 GMT
 Keep-Alive: timeout=5
 =========================== Response Binary  =========================== <<<
 00000000  08 01 12 1c 54 68 75 72  73 64 61 79 20 69 73 20  |....Thursday is |

--- a/test/suite/testcases.json
+++ b/test/suite/testcases.json
@@ -501,11 +501,27 @@
     "runAgainWithArg": "--no-curl"
   },
   {
-    "filename": "no-default-headers",
+    "filename": "no-default-headers-with-no-additional-headers",
     "args": [
       "-f happyday.proto -i happyday.HappyDayRequest -o happyday.HappyDayResponse -u http://localhost:8080/happy-day/verify",
       "-d \"includeReason: true, date: { seconds: 1648044939, nanos: 152000000 }\" -v",
-      "--curl -nH \"Content-Type: application/octet-stream\""
+      "-n --curl"
+    ]
+  },
+  {
+    "filename": "no-default-headers-with-custom-content-type-header",
+    "args": [
+      "-f happyday.proto -i happyday.HappyDayRequest -o happyday.HappyDayResponse -u http://localhost:8080/happy-day/verify",
+      "-d \"includeReason: true, date: { seconds: 1648044939, nanos: 152000000 }\" -v",
+      "--curl -n -H \"Content-Type: application/octet-stream\""
+    ]
+  },
+  {
+    "filename": "no-default-headers-with-no-curl-flag",
+    "args": [
+      "-f happyday.proto -i happyday.HappyDayRequest -o happyday.HappyDayResponse -u http://localhost:8080/happy-day/verify",
+      "-d \"includeReason: true, date: { seconds: 1648044939, nanos: 152000000 }\" -v",
+      "-n --no-curl"
     ]
   }
 ]

--- a/test/suite/testcases.json
+++ b/test/suite/testcases.json
@@ -499,5 +499,13 @@
     "filename": "version",
     "args": ["--version"],
     "runAgainWithArg": "--no-curl"
+  },
+  {
+    "filename": "no-default-headers",
+    "args": [
+      "-f happyday.proto -i happyday.HappyDayRequest -o happyday.HappyDayResponse -u http://localhost:8080/happy-day/verify",
+      "-d \"includeReason: true, date: { seconds: 1648044939, nanos: 152000000 }\" -v",
+      "--curl -nH \"Content-Type: application/octet-stream\""
+    ]
   }
 ]


### PR DESCRIPTION
I would like to use "Content-Type: application/octet-stream" (as it is in https://github.com/google/protorpc/blob/95849c9a3e414b9ba2d3da91fd850156348fe558/protorpc/protobuf.py#L50), but currently it is not possible because content-type header is defined in default headers ("Content-Type: application/x-protobuf") and not overwritten-able.

My use case is:
```bash
protocurl -u https://example.com/foo \
	-I ./proto -i ..ReqSomething -o ..ResSomething \
	-d 'something:"1"' --curl --protoc -v \
	-H "Content-Type: application/octet-stream" \
	-H "Accept: application/octet-stream"
```